### PR TITLE
Fix: Remove "onClear" implementation for "TomTomPolygonNode".

### DIFF
--- a/tomtom-compose/src/main/java/com/tomtom/maps/compose/TomTomPolygon.kt
+++ b/tomtom-compose/src/main/java/com/tomtom/maps/compose/TomTomPolygon.kt
@@ -26,10 +26,6 @@ internal class TomTomPolygonNode(
         polygon.remove()
     }
 
-    override fun onCleared() {
-        polygon.remove()
-    }
-
     override fun equals(other: Any?): Boolean =
         when(other) {
             is TomTomPolylineNode -> {


### PR DESCRIPTION
The implementation for the “onClear” function in the composable node for polygons was removed, since the exception was caused by a double call to the function to remove the polygon from the map.

- First clear call:

https://github.com/voidp-nt-r/tomtom-compose/blob/a7af1698893c8120ce484d315fbd1b074705b6e4/tomtom-compose/src/main/java/com/tomtom/maps/compose/TomTomMapApplier.kt#L38C1-L43C1

- #2